### PR TITLE
feat: add shields for twitter, discord, and github discussions

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,6 +9,13 @@
 </br>
 <h1 align="center">Welcome to the Nillion Network</h1>
 
+<p align="center">
+  <a href="https://twitter.com/nillionnetwork"><img src="https://img.shields.io/badge/NillionNetwork-000?color=0021F5&style=plastic&logo=twitter&logoColor=white&label=Twitter"></a>
+  <a href="https://discord.com/invite/nillionnetwork"><img src="https://img.shields.io/discord/905926225120338000?color=0021F5&style=plastic&label=Discord&logo=discord&logoColor=white"></a>
+  <a href="https://github.com/orgs/NillionNetwork/discussions"><img src="https://img.shields.io/badge/Developer-Technical_Questions-0021F5?color=0021F5&style=plastic&label=Github Discussions&logo=github&logoColor=white"></a>
+<br></br> 
+</p>
+
 Our goal is to build humanity's first blind computer. Nillion is a secure
 computation network that decentralizes trust for high value data in the same way
 that blockchains decentralized transactions.


### PR DESCRIPTION
Add clickable https://shields.io/ badges that link to twitter, discord, discussions

![image](https://github.com/NillionNetwork/.github/assets/91382964/720724d8-d0b6-49b2-8ac4-2ac7630b9a1e)
